### PR TITLE
220531 cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SpliceWiz
-Title: Exploration of differential alternative splicing events in splice-aware 
-  alignment BAM files
+Title: Efficient and precise alternative splicing analysis in R
 Version: 0.99.0
+Date: 2022-05-31
 Authors@R: c(person("Alex Chit Hei", "Wong", email="a.wong@centenary.org.au", 
 		role=c("aut", "cre", "cph")),
 	person("Ulf", "Schmitz", role=c("ctb")),

--- a/R/ASEFilter-methods.R
+++ b/R/ASEFilter-methods.R
@@ -4,7 +4,8 @@ ASEFilter <- function(
         filterClass = c("Data", "Annotation"),
         filterType = c(
             "Depth", "Participation", "Consistency",
-            "Protein_Coding", "NMD", "TSL", "Terminus", "ExclusiveMXE"
+            "Modality", "Protein_Coding", "NMD", "TSL", "Terminus", 
+            "ExclusiveMXE"
         ),
         pcTRUE = 100, minimum = 20, maximum = 1, minDepth = 5,
         condition = "", minCond = -1,
@@ -23,7 +24,8 @@ setMethod("initialize", "ASEFilter", function(.Object,
         filterClass = c("Data", "Annotation"),
         filterType = c(
             "Depth", "Participation", "Consistency",
-            "Protein_Coding", "NMD", "TSL", "Terminus", "ExclusiveMXE"
+            "Modality", "Protein_Coding", "NMD", "TSL", "Terminus", 
+            "ExclusiveMXE"
         ),
         pcTRUE = 100, minimum = 20, maximum = 1, minDepth = 5,
         condition = "", minCond = -1,
@@ -35,7 +37,7 @@ setMethod("initialize", "ASEFilter", function(.Object,
     # filterType <- match.arg(filterType)
 
     data_methods <- c("Depth", "Participation", "Consistency")
-    annotation_methods <- c("Protein_Coding", "NMD", "TSL",
+    annotation_methods <- c("Modality", "Protein_Coding", "NMD", "TSL",
         "Terminus", "ExclusiveMXE")
     
     if(filterClass %in% c("Data", "Annotation")) {
@@ -141,6 +143,8 @@ setMethod("show", "ASEFilter", function(object) {
         .nxtcat(paste0("Event Depth below ", .colourise("%i", "purple"),
             " are ignored\n"), as.integer(object@minDepth))
         .cat_filter_info("minDepth")
+    } else if (object@filterType == "Modality") {
+        cat("Events of the following modality are retained")
     } else if (object@filterType == "Protein_Coding") {
         cat("Events of which neither isoform encodes protein are removed")
     } else if (object@filterType == "NMD") {

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -127,10 +127,7 @@ setClass("NxtSE",
 #' retention events
 #'
 #' @param filterClass Must be either `"Data"` or `"Annotation"`. See details
-#' @param filterType If `filterClass = "Data"`, then must be one of 
-#'   `c("Depth", "Participation", "Consistency")`. 
-#'   If `filterClass = "Annotation"`,
-#'   must be one of `c("Protein_Coding", "NMD", "TSL")`. See details
+#' @param filterType Must be a valid `Annotation` or `Data` filter. See details
 #' @param pcTRUE If conditions are set, what percentage of all samples in each
 #'   of the condition must the filter be satisfied for the event to pass the
 #'   filter check. Must be between 0 and 100 (default 100)
@@ -150,11 +147,14 @@ setClass("NxtSE",
 #'   pass criteria. Set to `-1` when the number of elements in the experimental
 #'   condition is unknown. Ignored if `condition` is left blank.
 #' @param EventTypes What types of events are considered for filtering. Must be 
-#'   one of `c("IR", "MXE", "SE", "A3SS", "A5SS", "AFE", "ALE", "RI")`. Events 
-#'   not specified in `EventTypes` are not filtered (i.e. they will pass the
-#'   filter without checks)
+#'   one or more of `c("IR", "MXE", "SE", "A3SS", "A5SS", "AFE", "ALE", "RI")`. 
+#'   Events not specified in `EventTypes` are not filtered (i.e. they will pass
+#'   the filter without checks)
 #' @details
 #'   **Annotation Filters**
+#'   * **Modality**: Filters for specific modalities of ASEs. All events
+#'       belonging to the specified `EventTypes` are retained.
+#'       No additional parameters required.
 #'   * **Protein_Coding**: Filters for alternative splicing or IR events 
 #'       involving protein-coding transcripts.
 #'       No additional parameters required.

--- a/R/BuildRef.R
+++ b/R/BuildRef.R
@@ -2015,7 +2015,9 @@ return(TRUE)
         introns.unique.blacklisted <- findOverlaps(introns.unique,
             exclude.omnidirectional, type = "within"
         )
-        introns.unique <- introns.unique[-introns.unique.blacklisted@from]
+        if(length(introns.unique.blacklisted@from) > 0) {
+            introns.unique <- introns.unique[-introns.unique.blacklisted@from]
+        }
     }
 
     final <- list(

--- a/R/BuildRef.R
+++ b/R/BuildRef.R
@@ -3115,11 +3115,10 @@ return(TRUE)
                 intron_number_a = get("intron_number")[edge1],
                 intron_number_b = get("intron_number")[edge2]
             )
-        }, by = c("seqnames", "intron_coord")
+        }, by = c("seqnames", "strand", "intron_coord")
     ]
     introns_found_AFE <- introns_found_AFE[!is.na(get("gene_id"))]
     introns_found_AFE <- unique(introns_found_AFE, by = c("Event1a", "Event1b"))
-
     setorderv(introns_found_AFE, c("gene_id", "transcript_name_a"))
     introns_found_AFE <- introns_found_AFE[,
         c("EventName") := paste0(
@@ -3189,11 +3188,10 @@ return(TRUE)
                 intron_number_a = get("intron_number")[edge1],
                 intron_number_b = get("intron_number")[edge2]
             )
-        }, by = c("seqnames", "intron_coord")
+        }, by = c("seqnames", "strand", "intron_coord")
     ]
     introns_found_ALE <- introns_found_ALE[!is.na(get("gene_id"))]
     introns_found_ALE <- unique(introns_found_ALE, by = c("Event1a", "Event1b"))
-
     setorderv(introns_found_ALE, c("gene_id", "transcript_name_a"))
     introns_found_ALE <- introns_found_ALE[,
         c("EventName") := paste0("ALE:", get("transcript_name_a"), "-exon",
@@ -3272,22 +3270,23 @@ return(TRUE)
                 transcript_name_a = get("transcript_name")[edge1],
                 transcript_name_b = get("transcript_name")[edge2],
                 intron_number_a = get("intron_number")[edge1],
-                intron_number_b = get("intron_number")[edge2],
-                exon_groups_start_a = get("exon_groups_start")[edge1],
-                exon_groups_start_b = get("exon_groups_start")[edge2],
-                exon_groups_end_a = get("exon_groups_end")[edge1],
-                exon_groups_end_b = get("exon_groups_end")[edge2]
+                intron_number_b = get("intron_number")[edge2]#,
+                # exon_groups_start_a = get("exon_groups_start")[edge1],
+                # exon_groups_start_b = get("exon_groups_start")[edge2],
+                # exon_groups_end_a = get("exon_groups_end")[edge1],
+                # exon_groups_end_b = get("exon_groups_end")[edge2]
             )
-        }, by = "intron_coord"
+        }, by = c("seqnames", "strand", "intron_coord",
+            "exon_groups_start", "exon_groups_end")
     ]
     introns_found_A5SS <- introns_found_A5SS[!is.na(get("gene_id"))]
     introns_found_A5SS <- unique(introns_found_A5SS,
         by = c("Event1a", "Event1b"))
     # filter by same exon group starts and ends:
-    introns_found_A5SS <- introns_found_A5SS[
-        get("exon_groups_start_a") == get("exon_groups_start_b")]
-    introns_found_A5SS <- introns_found_A5SS[
-        get("exon_groups_end_a") == get("exon_groups_end_b")]
+    # introns_found_A5SS <- introns_found_A5SS[
+        # get("exon_groups_start_a") == get("exon_groups_start_b")]
+    # introns_found_A5SS <- introns_found_A5SS[
+        # get("exon_groups_end_a") == get("exon_groups_end_b")]
     setorderv(introns_found_A5SS, c("gene_id", "transcript_name_a"))
     introns_found_A5SS <- introns_found_A5SS[,
         c("EventName") := paste0(
@@ -3354,22 +3353,23 @@ return(TRUE)
                 transcript_name_a = get("transcript_name")[edge1],
                 transcript_name_b = get("transcript_name")[edge2],
                 intron_number_a = get("intron_number")[edge1],
-                intron_number_b = get("intron_number")[edge2],
-                exon_groups_start_a = get("exon_groups_start")[edge1],
-                exon_groups_start_b = get("exon_groups_start")[edge2],
-                exon_groups_end_a = get("exon_groups_end")[edge1],
-                exon_groups_end_b = get("exon_groups_end")[edge2]
+                intron_number_b = get("intron_number")[edge2]#,
+                # exon_groups_start_a = get("exon_groups_start")[edge1],
+                # exon_groups_start_b = get("exon_groups_start")[edge2],
+                # exon_groups_end_a = get("exon_groups_end")[edge1],
+                # exon_groups_end_b = get("exon_groups_end")[edge2]
             )
-        }, by = "intron_coord"
+        }, by = c("seqnames", "strand", "intron_coord",
+            "exon_groups_start", "exon_groups_end")
     ]
     introns_found_A3SS <- introns_found_A3SS[!is.na(get("gene_id"))]
     introns_found_A3SS <- unique(introns_found_A3SS,
         by = c("Event1a", "Event1b"))
     # filter by same exon group starts and ends:
-    introns_found_A3SS <- introns_found_A3SS[
-        get("exon_groups_start_a") == get("exon_groups_start_b")]
-    introns_found_A3SS <- introns_found_A3SS[
-        get("exon_groups_end_a") == get("exon_groups_end_b")]
+    # introns_found_A3SS <- introns_found_A3SS[
+        # get("exon_groups_start_a") == get("exon_groups_start_b")]
+    # introns_found_A3SS <- introns_found_A3SS[
+        # get("exon_groups_end_a") == get("exon_groups_end_b")]
 
     setorderv(introns_found_A3SS, c("gene_id", "transcript_name_a"))
     introns_found_A3SS <- introns_found_A3SS[,

--- a/R/BuildRef.R
+++ b/R/BuildRef.R
@@ -687,12 +687,12 @@ return(TRUE)
     if(is_valid(filename) && file.exists(filename)) {
         tryCatch(
             gr <- rtracklayer::import.bed(filename, "bed"),
-            error = function(x) NULL
+            error = function(x) NULL, warning = function(x) NULL
         )
         if(!is.null(gr)) return(gr)
         tryCatch({
                 gr <- readRDS(filename)
-            }, error = function(e) NULL
+            }, error = function(e) NULL, warning = function(x) NULL
         )
         if(!is.null(gr)) return(gr)
     }

--- a/R/Coverage.R
+++ b/R/Coverage.R
@@ -309,7 +309,14 @@ as_ggplot_cov <- function(p_obj) {
 
     plot_tracks <- p_obj$ggplot[
         unlist(lapply(p_obj$ggplot, function(x) !is.null(x)))]
-    egg::ggarrange(plots = plot_tracks, ncol = 1)
+    
+    # Catch any unexpected errors
+    tryCatch({
+        egg::ggarrange(plots = plot_tracks, ncol = 1)
+    }, error = function(x) {
+        .log(x, "message")
+        return(NULL)
+    })
 }
 
 #' Calls SpliceWiz's C++ function to retrieve coverage from a COV file

--- a/R/Filters.R
+++ b/R/Filters.R
@@ -126,7 +126,10 @@ runFilter <- function(se, filterObj) {
             return(.runFilter_data_consistency(se, filterObj))
         }
     } else if (filterObj@filterClass == "Annotation") {
-        if (filterObj@filterType == "Protein_Coding") {
+        if (filterObj@filterType == "Modality") {
+            message("Running Modality filter")
+            return(.runFilter_anno_mode(se, filterObj))
+        } else if (filterObj@filterType == "Protein_Coding") {
             message("Running Protein_Coding filter")
             return(.runFilter_anno_pc(se, filterObj))
         } else if (filterObj@filterType == "NMD") {
@@ -315,6 +318,14 @@ runFilter <- function(se, filterObj) {
     sum <- rowSums(truth_total)
     
     return(sum)
+}
+
+# returns if any of included or excluded is protein_coding
+.runFilter_anno_mode <- function(se, filterObj) {
+    rowSelected <- as.data.table(rowData(se))
+    rowSelected <- rowSelected[get("EventType") %in% filterObj@EventTypes]
+    res <- rowData(se)$EventName %in% rowSelected$EventName
+    return(res)
 }
 
 # returns if any of included or excluded is protein_coding

--- a/R/dash_DE_server.R
+++ b/R/dash_DE_server.R
@@ -229,6 +229,14 @@ server_DE <- function(
                 })
             }
             
+            # Allow filtering by EventType: factorize it
+            if(
+                    is(res.ASE$EventType, "character") && 
+                    length(unique(res.ASE$EventType)) > 1
+            ) {
+                res.ASE$EventType <- factor(res.ASE$EventType)
+            }
+            
             settings_DE$res <- as.data.frame(res.ASE)
             output$warning_DE <- renderText({"Finished"})
 

--- a/R/dash_filterModules.R
+++ b/R/dash_filterModules.R
@@ -121,8 +121,8 @@ filterModule_server <- function(id, filterdata, conditionList) {
             fClass <- final()@filterClass
             if(is_valid(fClass) && fClass %in% class_choices) {
                 if(fClass == "Annotation") {
-                    type_choices <- c("Protein_Coding", "NMD", "TSL", 
-                        "Terminus", "ExclusiveMXE")
+                    type_choices <- c("Modality", "Protein_Coding", "NMD", 
+                        "TSL", "Terminus", "ExclusiveMXE")
                 } else if(fClass == "Data") {
                     type_choices <- c("Depth", "Participation", "Consistency")
                 }
@@ -221,8 +221,8 @@ filterModule_server <- function(id, filterdata, conditionList) {
             obj <- final()
             obj@filterClass <- input$filterClass
             if(input$filterClass == "Annotation") {
-                type_choices <- c("Protein_Coding", "NMD", "TSL", 
-                    "Terminus", "ExclusiveMXE")
+                type_choices <- c("Modality", "Protein_Coding", "NMD", 
+                        "TSL", "Terminus", "ExclusiveMXE")
             } else if(input$filterClass == "Data") {
                 type_choices <- c("Depth", "Participation", "Consistency")
             } else {

--- a/R/dash_filters.R
+++ b/R/dash_filters.R
@@ -54,6 +54,7 @@ server_filters <- function(
             if(is_valid(get_se())) {
                 output$current_expr_Filters <- 
                     renderText("NxtSE loaded")
+                req(!is_valid(settings_filter$filterSummary))
                 processFilters()
             } else {
                 output$current_expr_Filters <- 

--- a/R/dash_vis_server.R
+++ b/R/dash_vis_server.R
@@ -36,7 +36,7 @@ server_vis_diag <- function(
         })
         observeEvent(rows_selected(), {
             settings_Diag$selected <- rows_selected()
-        })
+        }, ignoreNULL = FALSE)
     
         output$plot_diag <- renderPlotly({
             # settings_Diag$plot_ini = FALSE
@@ -280,9 +280,9 @@ server_vis_volcano <- function(
             req(refresh_tab())
         })
         observeEvent(rows_selected(), {
-            print(rows_selected())
+            # print(rows_selected())
             settings_Volc$selected <- rows_selected()
-        })
+        }, ignoreNULL = FALSE)
 
         settings_Volc$plotly_click <- reactive({
             plot_exist <- settings_Volc$plot_ini

--- a/R/dash_vis_server.R
+++ b/R/dash_vis_server.R
@@ -402,7 +402,7 @@ server_vis_volcano <- function(
             settings_Volc$final_plot <- ggplotly(
                 p, tooltip = "text",
                 source = "plotly_volcano"
-            ) %>% layout(dragmode = "lasso")
+            ) %>% layout(dragmode = "select")
             
             print(
                 settings_Volc$final_plot

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -30,12 +30,18 @@ get_multi_DT_from_gz <- function(infile = "",
         for (j in seq_len(length(df.list[[i]]))) {
             # suppressWarnings to supress "NAs introduced by coercion"
             # Intent of the function is to convert these to `NA`
-            suppressWarnings({
-                if (all(df.list[[i]][[j]] == "NA" |
-                        !is.na(as.numeric(df.list[[i]][[j]])))) {
-                    df.list[[i]][[j]] <- as.numeric(df.list[[i]][[j]])
-                }
-            })
+            # suppressWarnings({
+                # if (all(df.list[[i]][[j]] == "NA" |
+                        # !is.na(as.numeric(df.list[[i]][[j]])))) {
+                    # df.list[[i]][[j]] <- as.numeric(df.list[[i]][[j]])
+                # }
+            # })
+            testNA <- tryCatch({
+                as.numeric(df.list[[i]][[j]])
+                }, warning = function(e) NA
+            )
+            if(all(!is.na(testNA))) 
+                df.list[[i]][[j]] <- as.numeric(df.list[[i]][[j]])
         }
         df.list[[i]] <- as.data.table(df.list[[i]])
     }

--- a/inst/scripts/make-data.R
+++ b/inst/scripts/make-data.R
@@ -3,7 +3,8 @@
 #' Making a Mappability Region Exclusion BED file requires 3 steps.
 #'   1) Generate mappability reads using `run_IRFinder_GenerateMapReads()`, 
 #'      using the primary assembly genome FASTA as `genome.fa`
-#'   2) Align `out.fa` to the corresponding genome using a genome splice-aware aligner such as STAR
+#'   2) Align `out.fa` to the corresponding genome using a genome splice-aware 
+#'      aligner such as STAR
 #'   3) Process the aligned BAM file using `run_IRFinder_MapExclusionRegions()`
 #' @examples
 #' \dontrun{
@@ -35,7 +36,7 @@
 #' }
 NULL
 
-#' Sample NxtSE object using the NxtIRF example reference and example bam files
+#' Sample NxtSE object using the example reference and example bam files
 #'
 #' This function generates an example reference, and runs IRFinder on example
 #' bam files. This object is used in downstream examples throughout

--- a/man/ASEFilter-class.Rd
+++ b/man/ASEFilter-class.Rd
@@ -9,8 +9,8 @@ retention events}
 \usage{
 ASEFilter(
   filterClass = c("Data", "Annotation"),
-  filterType = c("Depth", "Participation", "Consistency", "Protein_Coding", "NMD",
-    "TSL", "Terminus", "ExclusiveMXE"),
+  filterType = c("Depth", "Participation", "Consistency", "Modality", "Protein_Coding",
+    "NMD", "TSL", "Terminus", "ExclusiveMXE"),
   pcTRUE = 100,
   minimum = 20,
   maximum = 1,
@@ -23,10 +23,7 @@ ASEFilter(
 \arguments{
 \item{filterClass}{Must be either \code{"Data"} or \code{"Annotation"}. See details}
 
-\item{filterType}{If \code{filterClass = "Data"}, then must be one of
-\code{c("Depth", "Participation", "Consistency")}.
-If \code{filterClass = "Annotation"},
-must be one of \code{c("Protein_Coding", "NMD", "TSL")}. See details}
+\item{filterType}{Must be a valid \code{Annotation} or \code{Data} filter. See details}
 
 \item{pcTRUE}{If conditions are set, what percentage of all samples in each
 of the condition must the filter be satisfied for the event to pass the
@@ -53,9 +50,9 @@ pass criteria. Set to \code{-1} when the number of elements in the experimental
 condition is unknown. Ignored if \code{condition} is left blank.}
 
 \item{EventTypes}{What types of events are considered for filtering. Must be
-one of \code{c("IR", "MXE", "SE", "A3SS", "A5SS", "AFE", "ALE", "RI")}. Events
-not specified in \code{EventTypes} are not filtered (i.e. they will pass the
-filter without checks)}
+one or more of \code{c("IR", "MXE", "SE", "A3SS", "A5SS", "AFE", "ALE", "RI")}.
+Events not specified in \code{EventTypes} are not filtered (i.e. they will pass
+the filter without checks)}
 }
 \value{
 A ASEFilter object with the specified parameters
@@ -67,6 +64,9 @@ retention events
 \details{
 \strong{Annotation Filters}
 \itemize{
+\item \strong{Modality}: Filters for specific modalities of ASEs. All events
+belonging to the specified \code{EventTypes} are retained.
+No additional parameters required.
 \item \strong{Protein_Coding}: Filters for alternative splicing or IR events
 involving protein-coding transcripts.
 No additional parameters required.

--- a/vignettes/SW_Cookbook.Rmd
+++ b/vignettes/SW_Cookbook.Rmd
@@ -26,6 +26,7 @@ knitr::opts_chunk$set(
     comment = "#>"
 )
 ```
+\
 
 # Loading SpliceWiz
 
@@ -35,6 +36,7 @@ Quick-Start vignette.
 ```{r}
 library(SpliceWiz)
 ```
+\
 
 # Reference Generation
 
@@ -45,12 +47,15 @@ otherwise an error will be returned.
 ```{r eval = FALSE}
 ref_path <- "./Reference"
 ```
+\
+
 
 ### Create a SpliceWiz reference from user-defined FASTA and GTF files locally
 
-Note that setting `genome_path = "hg38"` will prompt SpliceWiz to use the default
-files for nonPolyA and Mappability exclusion references in the generation of its
-reference. Valid options for `genome_path` are "hg38", "hg19", "mm10" and "mm9".
+Note that setting `genome_path = "hg38"` will prompt SpliceWiz to use the 
+default files for nonPolyA and Mappability exclusion references in the 
+generation of its reference. Valid options for `genome_path` are "hg38", "hg19",
+"mm10" and "mm9".
 
 ```{r eval=FALSE}
 buildRef(
@@ -59,6 +64,36 @@ buildRef(
     genome_type = "hg38"
 )
 ```
+\
+
+### Prepare genome resources and building the reference as separate steps
+
+`buildRef()` first fetches the genome and gene annotations and makes a 
+compressed local copy in the `resources` subdirectory of the given reference
+path. This can sometimes be a long process (especially when downloading the
+genome from the internet). Also, one may choose to generate the mappability
+exclusion regions manually (see `Reference Generation` - 
+`Mappability exclusion generation using Rsubread` section). This needs to occur
+prior to generation of the SpliceWiz reference.
+
+To separately prepare the annotation data and build the SpliceWiz reference,
+use the `getResources()` function to specify the FASTA and GTF files. Once
+`getResources()` has completed successfully, call `buildRef()` and leave
+the `fasta` and `gtf` arguments blank, as in the example below:
+
+```{r eval=FALSE}
+getResources(
+    reference_path = ref_path,
+    fasta = "genome.fa",
+    gtf = "transcripts.gtf"
+)
+
+buildRef(
+    reference_path = ref_path,
+    genome_type = "hg38"
+)
+```
+\
 
 ### Create a SpliceWiz reference using web resources from Ensembl's FTP
 
@@ -79,6 +114,7 @@ buildRef(
     genome_type = "hg38"
 )
 ```
+\
 
 ### Create a SpliceWiz reference using AnnotationHub resources
 
@@ -110,9 +146,10 @@ buildRef(
 )
 ```
 
-`Build-Reference-methods` will recognise the inputs of `fasta` and `gtf` as AnnotationHub
-resources as they begin with "AH".
-
+`Build-Reference-methods` will recognise the inputs of `fasta` and `gtf` as
+AnnotationHub resources as they begin with "AH".
+\
+\
 ### Create a SpliceWiz reference from species other than human or mouse
 
 For human and mouse genomes, we highly recommend specifying `genome_type` as
@@ -127,6 +164,7 @@ buildRef(
     genome_type = ""
 )
 ```
+\
 
 ### Building a STAR reference alongside the SpliceWiz reference
 
@@ -151,6 +189,8 @@ buildFullRef(
 
 `n_threads` specify how many threads should be used to build the STAR reference
 and to calculate the low mappability regions
+\
+\
 
 ### Mappability exclusion generation using Rsubread
 
@@ -206,8 +246,10 @@ calculateMappability(
 buildRef(ref_path)      
 
 ```
+\
 
 # Aligning Raw RNA-seq data using SpliceWiz's STAR wrappers
+\
 
 ### Checking if STAR is installed
 
@@ -218,6 +260,7 @@ This software is not available in Windows. To check if `STAR` is available:
 ```{r}
 STAR_version()
 ```
+\
 
 ### Building a STAR reference
 
@@ -242,6 +285,7 @@ STAR_BuildRef(
 )
 
 ```
+\
 
 ### Aligning a single sample using STAR
 
@@ -253,6 +297,7 @@ STAR_alignReads(
     n_threads = 8
 )
 ```
+\
 
 ### Aligning multiple samples using STAR
 
@@ -276,6 +321,8 @@ STAR_alignExperiment(
 
 To use two-pass mapping, set `two_pass = TRUE`. We recommend disabling this
 feature, as one-pass mapping is adequate in typical-use cases.
+\
+\
 
 # Running processBAM on BAM files
 
@@ -303,6 +350,7 @@ processBAM(
     useOpenMP = TRUE
 )
 ```
+\
 
 ### Creating COV files from BAM files without running processBAM
 
@@ -324,8 +372,9 @@ BAM2COV(
     useOpenMP = TRUE
 )
 ```
+\
 
-# Collating the experiment:
+# Collating the experiment
 
 Assuming the SpliceWiz reference is in `ref_path`, after running `processBAM()`
 as shown in the previous section, use the convenience function 
@@ -353,11 +402,14 @@ additional data required by SpliceWiz.
 ```{r eval = FALSE}
 se <- makeSE("./NxtSE_output")
 ```
+\
 
-## Downstream analysis using SpliceWiz
+# Downstream analysis using SpliceWiz
 
 Please refer to SpliceWiz: Quick-Start vignette for worked examples using the 
 example dataset.
+\
+\
 
 # SessionInfo
 

--- a/vignettes/SW_QuickStart.Rmd
+++ b/vignettes/SW_QuickStart.Rmd
@@ -115,7 +115,7 @@ in the RStudio environment. To start using SpliceWiz GUI:
 
 ```{r}
 if(interactive()) {
-	spliceWiz(demo = TRUE)
+    spliceWiz(demo = TRUE)
 }
 ```
 \

--- a/vignettes/SW_QuickStart.Rmd
+++ b/vignettes/SW_QuickStart.Rmd
@@ -24,6 +24,7 @@ knitr::opts_chunk$set(
     comment = "#>"
 )
 ```
+\
 
 # Introduction
 
@@ -46,6 +47,8 @@ like these, where available.
 
 For a list of ready-made "recipes" for typical-use SpliceWiz in real datasets, 
 refer to the vignette: `SpliceWiz: Cookbook`.
+\
+\
 
 # Workflow from a glance
 
@@ -58,6 +61,8 @@ The basic steps of SpliceWiz are as follows:
 * Alternative splicing event filtering
 * Differential ASE analysis
 * Visualization
+\
+\
 
 # Quick-Start
 
@@ -84,6 +89,7 @@ quickest way to get started is to install `libomp` via brew:
 brew install libomp
 ```
 </details> 
+\
 
 ## Loading SpliceWiz
 
@@ -241,6 +247,7 @@ buildRef(
 )
 ```
 </details>
+\
 
 ## Process BAM files using SpliceWiz
 
@@ -497,6 +504,7 @@ exons. `SpliceOver` is the default option.
 We estimate it can use up to 6-7 Gb per thread. `lowMemoryMode` will minimise
 RAM usage to ~ 8 Gb, but will be slower and run on a single thread.\
 </details>
+\
 
 ## Importing the experiment
 
@@ -683,6 +691,7 @@ se_ASE_subset <- se[1:10,]
 ```
 \
 </details>
+\
 
 ### Filtering high-confidence events
 
@@ -727,6 +736,7 @@ depths at 100-million paired-end reads.
 
 To learn more about filters, consult the documentation via `?ASEFilters`
 </details>
+\
 
 ### Performing differential analysis
 
@@ -856,6 +866,7 @@ res_deseq_cont <- ASE_DESeq(
 ```
 \
 <\details>
+\
 
 ## Visualization
 
@@ -864,7 +875,7 @@ res_deseq_cont <- ASE_DESeq(
 Volcano plots show changes in PSI levels (log fold change, x axis) against
 statistical significance (-log10 p values, y axis):
 
-```{r, fig.width = 7, fig.height = 5}
+```{r, fig.width = 7, fig.height = 5, eval = Sys.info()["sysname"] != "Darwin"}
 library(ggplot2)
 
 ggplot(res_limma,
@@ -882,7 +893,7 @@ Yes. We can use `ggplot2`'s `facet_wrap` function to separately plot volcanos
 for each modality of ASE. The type of ASE is contained in the `EventType` column
 of the differential results data frame.
 
-```{r, fig.width = 7, fig.height = 5}
+```{r, fig.width = 7, fig.height = 5, eval = Sys.info()["sysname"] != "Darwin"}
 ggplot(res_limma,
         aes(x = logFC, y = -log10(adj.P.Val))) + 
     geom_point() + facet_wrap(vars(EventType)) +
@@ -928,7 +939,7 @@ Scatter plots are useful for showing splicing levels (percent-spliced-in, PSI)
 between two conditions. The results from differential analysis contains these
 values and can be plotted:
 
-```{r, fig.width = 7, fig.height = 5}
+```{r, fig.width = 7, fig.height = 5, eval = Sys.info()["sysname"] != "Darwin"}
 library(ggplot2)
 
 ggplot(res_limma, aes(x = 100 * AvgPSI_B, y = 100 * AvgPSI_A)) + 
@@ -1021,6 +1032,7 @@ mat <- makeMatrix(
     method = "PSI"
 )
 ```
+\
 
 <details>
 <summary>How does `makeMatrix()` work?</summary>
@@ -1045,6 +1057,7 @@ parameter `na.percent.max` (default `0.1`) means any ASE with the proportion of
 `NA` above this threshold will be removed from the final matrix.
 \
 </details>
+\
 
 Plot this matrix of values in a heatmap:
 
@@ -1083,11 +1096,11 @@ the selected annotation categories
 </details>
 \
 
-### SpliceWiz Coverage Plots
+## SpliceWiz Coverage Plots
 
 Coverage plots visualize RNA-seq coverage in individual samples. SpliceWiz uses
 its coverage normalization algorithm to visualize group differences in PSIs.
-
+\
 <details>
 <summary>What are SpliceWiz coverage plots and how are they generated?</summary>
 \
@@ -1107,8 +1120,9 @@ the intron depths reflect the fraction of transcripts with retained introns and
 can be compared across samples.
 \
 </details>
+\
 
-#### Coverage plots of individual samples
+### Coverage plots of individual samples
 
 First, lets obtain a list of differential events with delta PSI > 5%:
 
@@ -1118,7 +1132,7 @@ res_limma.filtered <- subset(res_limma, abs(AvgPSI_A - AvgPSI_B) > 0.05)
 
 Plot up to 4 individual samples using `plotCoverage()`:
 
-```{r, fig.width = 8, fig.height = 6}
+```{r, fig.width = 8, fig.height = 6, eval = Sys.info()["sysname"] != "Darwin"}
 p <- plotCoverage(
     se = se,
     Event = res_limma.filtered$EventName[1],
@@ -1134,6 +1148,7 @@ if(interactive()) {
 }
 
 ```
+\
 
 <details>
 <summary>The genome track is too cluttered! How can I customize it?</summary>
@@ -1143,7 +1158,7 @@ to only display the specified transcripts. Selected transcripts can be supplied
 by name or ID (`transcript_name` and `transcript_id` field in the GTF file,
 respectively)
 
-```{r}
+```{r, eval = Sys.info()["sysname"] != "Darwin"}
 p <- plotCoverage(
     se = se,
     Event = res_limma.filtered$EventName[1],
@@ -1161,13 +1176,14 @@ if(interactive()) {
 ```
 \
 </details>
+\
 
-#### Group-averaged coverage plots
+### Group-averaged coverage plots
 
 We plot average coverages of groups "A" and "B" of the "condition" category,
 as follows:
 
-```{r, fig.width = 8, fig.height = 6}
+```{r, fig.width = 8, fig.height = 6, eval = Sys.info()["sysname"] != "Darwin"}
 p <- plotCoverage(
     se = se,
     Event = res_limma.filtered$EventName[1],
@@ -1200,7 +1216,7 @@ introns) gives a sense of how differentially expressed these regions are.
 </details>
 \
 
-#### Using the GUI
+### Using the GUI
 
 Click on `Display` and then `Coverage plot` from the menu side bar. 
 It should look like this:
@@ -1215,9 +1231,9 @@ Coverage plots can be customized as follows:
 * (2) Events: display individual ASE events
 * (3) Coordinates: display by genomic coordinates
 * (4) Zoom in or out (each step is a factor of 3)
-* (5) Strand: select unstranded (*), positive (+) or negative (-). NB most RNA-seq
-protocols are reverse-stranded; this means the strand is opposite to that of the
-expressed RNA
+* (5) Strand: select unstranded (*), positive (+) or negative (-). NB most 
+RNA-seq protocols are reverse-stranded; this means the strand is opposite to 
+that of the expressed RNA
 * (6) Select events ranked by p values from All results, Filtered results (using
 the interactive DT data table), or Selected results using lasso / box select
 tools on the volcano or scatter plots
@@ -1241,6 +1257,7 @@ and per-window t-test results (-log10 transformed) will be displayed. Higher
 values indicate higher significance
 * (16) Condensed tracks: whether the individual transcripts `OFF` or collapsed
 combined transcripts `ON` is displayed
+\
 
 # SessionInfo
 


### PR DESCRIPTION
* BUGFIX: A5SS / A3SS annotations sometimes had chimeric chromosomes and/or opposite strand
* bugfix: buildRef() crash when Mappability does not exclude any whole introns
* Improved spacing between vignette sections
* Fixed warning messages with using Mappability resources as RDS files
* Removes unnecessary suppressWarning() brackets
* Disable ggplot generation for MacOS vignettes (ggplot can give 'polygon edge not found' errors)
* Miscellaneous formatting improvements to improve BiocCheck results